### PR TITLE
[PLAT-2507] Update recipe optionally build versions not published in CCI

### DIFF
--- a/recipe/all/conanfile.py
+++ b/recipe/all/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.microsoft import is_msvc_static_runtime
 import functools
 import os
 
-required_conan_version = ">=1.51.3"
+required_conan_version = ">=1.59.0"
 
 
 class OpenTDFConan(ConanFile):
@@ -22,6 +22,10 @@ class OpenTDFConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     options = {"fPIC": [True, False]}
     default_options = {"fPIC": True}
+    # REMOVE_FOR_CCI BEGIN
+    options = {"fPIC": [True, False], "branch_version": [True, False]}
+    default_options = {"fPIC": True, "branch_version": False}
+    # REMOVE_FOR_CCI END
 
     @property
     def _source_subfolder(self):
@@ -70,6 +74,7 @@ class OpenTDFConan(ConanFile):
         self.requires("ms-gsl/2.1.0")
         self.requires("nlohmann_json/3.11.1")
         self.requires("jwt-cpp/0.4.0")
+        self.requires("magic_enum/0.8.2")
         # Use newer boost+libxml2 after 1.3.6
         if Version(self.version) <= "1.3.6":
             self.requires("boost/1.79.0")
@@ -83,7 +88,13 @@ class OpenTDFConan(ConanFile):
             del self.options.fPIC
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+    #REMOVE_FOR_CCI BEGIN
+        if self.options.branch_version:
+            self.output.warn("Building branch_version = {}".format(self.version))
+            self.run("git clone git@github.com:opentdf/client-cpp.git --depth 1 --branch " + self.version + " " + self._source_subfolder)
+        else:
+    #REMOVE_FOR_CCI END
+            get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     def _patch_sources(self):
         for data in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipe/all/conanfile.py
+++ b/recipe/all/conanfile.py
@@ -12,8 +12,24 @@ required_conan_version = ">=1.59.0"
 
 #REMOVE_FOR_CCI BEGIN
 # This recipe contains sections that will not be approved by Conan Center Index reviewers.
-# All code between the BEGIN/END comments should be removed before submitting this recipe
-# to CCI
+# All code between the BEGIN/END comments should be removed before submitting this recipe to CCI
+#
+# Options:
+#   branch_version - Default: False.  Set to True to have recipe use the supplied version as a branch/tag/release name 
+#                    to pull source from the client-cpp repo, instead of the usual static entry in the conandata.yml list.
+#                    Once the specified version has been built to the local cache, it can be consumed 
+#                    by other projects using that same name as the version
+#
+#                    Examples: 
+#                    Build from the 1.4.0 release tag in client-cpp:
+#                    conan create recipe/all opentdf-client/1.4.0@ --build=opentdf-client --build=missing -o opentdf-client:branch_version=True
+#                    Consume from cache:
+#                    self.requires("opentdf-client/1.4.0@")
+#
+#                    Build from the PLAT-1234-my-changes branch in client-cpp:
+#                    conan create recipe/all opentdf-client/PLAT-1234-my-changes@ --build=opentdf-client --build=missing -o opentdf-client:branch_version=True
+#                    Consume from cache:
+#                    self.requires("opentdf-client/PLAT-1234-changes@")
 #REMOVE_FOR_CCI END
 
 class OpenTDFConan(ConanFile):

--- a/recipe/all/conanfile.py
+++ b/recipe/all/conanfile.py
@@ -10,6 +10,11 @@ import os
 
 required_conan_version = ">=1.59.0"
 
+#REMOVE_FOR_CCI BEGIN
+# This recipe contains sections that will not be approved by Conan Center Index reviewers.
+# All code between the BEGIN/END comments should be removed before submitting this recipe
+# to CCI
+#REMOVE_FOR_CCI END
 
 class OpenTDFConan(ConanFile):
     name = "opentdf-client"
@@ -22,10 +27,10 @@ class OpenTDFConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     options = {"fPIC": [True, False]}
     default_options = {"fPIC": True}
-    # REMOVE_FOR_CCI BEGIN
+    #REMOVE_FOR_CCI BEGIN
     options = {"fPIC": [True, False], "branch_version": [True, False]}
     default_options = {"fPIC": True, "branch_version": False}
-    # REMOVE_FOR_CCI END
+    #REMOVE_FOR_CCI END
 
     @property
     def _source_subfolder(self):

--- a/recipe/all/conanfile.py
+++ b/recipe/all/conanfile.py
@@ -91,7 +91,7 @@ class OpenTDFConan(ConanFile):
     #REMOVE_FOR_CCI BEGIN
         if self.options.branch_version:
             self.output.warn("Building branch_version = {}".format(self.version))
-            self.run("git clone git@github.com:opentdf/client-cpp.git --depth 1 --branch " + self.version + " " + self._source_subfolder)
+            self.run("git clone https://github.com/opentdf/client-cpp.git --depth 1 --branch " + self.version + " " + self._source_subfolder)
         else:
     #REMOVE_FOR_CCI END
             get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)


### PR DESCRIPTION
Add branch_version option to conan recipe to allow using the version as a GH branch/tag name to pull source instead of just using the static conandata.yml list.